### PR TITLE
feat: challenge 기능 구현

### DIFF
--- a/src/main/java/com/spring/GreenJoy/GreenJoyApplication.java
+++ b/src/main/java/com/spring/GreenJoy/GreenJoyApplication.java
@@ -3,7 +3,9 @@ package com.spring.GreenJoy;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication()
 public class GreenJoyApplication {

--- a/src/main/java/com/spring/GreenJoy/domain/challenge/ChallengeController.java
+++ b/src/main/java/com/spring/GreenJoy/domain/challenge/ChallengeController.java
@@ -1,0 +1,48 @@
+package com.spring.GreenJoy.domain.challenge;
+
+import com.spring.GreenJoy.domain.challenge.dto.CreateAndUpdateChallengeRequest;
+import com.spring.GreenJoy.domain.challenge.dto.GetChallengeListResponse;
+import com.spring.GreenJoy.domain.challenge.dto.GetChallengeResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/challenge")
+@RequiredArgsConstructor
+public class ChallengeController {
+
+    private final ChallengeService challengeService;
+
+    @GetMapping("/today")
+    public ResponseEntity<?> createTodayChallenge() {
+        String todayChallenge = challengeService.createTodayChallenge();
+        return ResponseEntity.ok().body(todayChallenge.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @PostMapping
+    public ResponseEntity<?> certifyChallenge(@ModelAttribute CreateAndUpdateChallengeRequest createAndUpdateChallengeRequest) throws IOException {
+        String todayChallenge = challengeService.certifyChallenge(createAndUpdateChallengeRequest);
+        return ResponseEntity.ok().body("챌린지 업로드 성공".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getChallengeList(@RequestParam("randomId") String randomId, Pageable pageable) {
+        Page<GetChallengeListResponse> challengeListResponse = challengeService.getChallengeList(randomId, pageable);
+        return ResponseEntity.ok().body(challengeListResponse);
+    }
+
+    @GetMapping("/{challengeId}")
+    public ResponseEntity<?> getChallenge(@PathVariable("challengeId") Long challengeId) {
+        GetChallengeResponse challenge = challengeService.getChallenge(challengeId);
+        return ResponseEntity.ok().body(challenge);
+    }
+
+}

--- a/src/main/java/com/spring/GreenJoy/domain/challenge/ChallengeRepository.java
+++ b/src/main/java/com/spring/GreenJoy/domain/challenge/ChallengeRepository.java
@@ -1,0 +1,19 @@
+package com.spring.GreenJoy.domain.challenge;
+
+import com.spring.GreenJoy.domain.challenge.entity.Challenge;
+import com.spring.GreenJoy.global.common.NanoId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
+
+    Optional<Challenge> findByChallengeDateAndActiveOrderByCreatedAtDesc(LocalDate todayDate, boolean active);
+    List<Challenge> findAllByChallengeDateAndActiveOrderByCreatedAtDesc(LocalDate todayDate, boolean active);
+    Page<Challenge> findByUser_UserIdOrderByCreatedAtDesc(NanoId randomId, Pageable pageable);
+
+}

--- a/src/main/java/com/spring/GreenJoy/domain/challenge/ChallengeService.java
+++ b/src/main/java/com/spring/GreenJoy/domain/challenge/ChallengeService.java
@@ -1,0 +1,154 @@
+package com.spring.GreenJoy.domain.challenge;
+
+import com.spring.GreenJoy.domain.challenge.dto.CreateAndUpdateChallengeRequest;
+import com.spring.GreenJoy.domain.challenge.dto.GetChallengeListResponse;
+import com.spring.GreenJoy.domain.challenge.dto.GetChallengeResponse;
+import com.spring.GreenJoy.domain.challenge.entity.Challenge;
+import com.spring.GreenJoy.domain.image.ImageService;
+import com.spring.GreenJoy.domain.user.UserRepository;
+import com.spring.GreenJoy.domain.user.entity.User;
+import com.spring.GreenJoy.global.common.NanoId;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChallengeService {
+
+    private final ChallengeRepository challengeRepository;
+    private final UserRepository userRepository;
+
+    private final ImageService imageService;
+
+    /**
+     * 오늘의 챌린지 생성: scheduler
+     */
+    // @Scheduled(cron = "*/30 * * * * *") // 30초 마다 변경 (Test Code)
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정 변경
+    public String createTodayChallenge() {
+        List<User> userList  = userRepository.findAll();
+
+        String todayChallenge = getTodayChallenge();
+        LocalDate todayDate = LocalDate.now();
+
+        for(User user : userList){
+            Challenge challenge = challengeRepository.save(Challenge.builder()
+                    .title(todayChallenge)
+                    .content(null)
+                    .image(null)
+                    .user(user)
+                    .active(false)
+                    .challengeDate(todayDate)
+                    .build());
+        }
+
+        return todayChallenge;
+    }
+
+    /**
+     * 오늘의 챌린지 생성: getter
+     * @return 오늘의 챌린지
+     */
+    private static String getTodayChallenge() {
+        List<String> todayChallengeList = Arrays.asList(
+                "텀블러 사용하기", "자전거 또는 대중교통 이용하기", "쓰레기 분리수거하기",
+                "지역 농산물 구매하기", "종이 사용 줄이기 (디지털 문서 사용하기)",
+                "잔반 남기지 않기", "비건(채식) 식단 해보기", "일회용 비닐 사용 안하기",
+                "다회용기를 이용해서 포장하기", "친환경 제품 사용하기", "안 쓰는 콘센트 뽑기",
+                "물 사용 절약하기", "샤워 시간 줄이기", "양치컵 쓰기", "중고제품 구매하기",
+                "만보 걷기", "걸어서 이동하기", "나갈 때 전등 끄기", "녹색제품 인증 마크 상품 구입하기"
+        );
+
+        Random random = new Random();
+        String todayChallenge = todayChallengeList.get(random.nextInt(todayChallengeList.size()));
+
+        return todayChallenge;
+    }
+
+    /**
+     * 오늘의 챌린지 인증 (USER)
+     */
+    public String certifyChallenge(CreateAndUpdateChallengeRequest createAndUpdateChallengeRequest) throws IOException {
+        User user = userRepository.findById(NanoId.of(createAndUpdateChallengeRequest.randomId()))
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        LocalDate todayDate = LocalDate.now();
+        // Optional<Challenge> todayChallenge = challengeRepository.findByChallengeDateAndActive(todayDate, false);
+        List<Challenge> challengeList = challengeRepository.findAllByChallengeDateAndActiveOrderByCreatedAtDesc(todayDate, false);
+
+        String todayChallenge = null;
+
+        if(!challengeList.isEmpty()) {
+            Challenge lastChallenge = challengeList.get(challengeList.size()-1);
+            todayChallenge = lastChallenge.getTitle();
+
+            log.info("오늘의 챌린지는: " + todayChallenge);
+        } else {
+            return "아직 오늘의 챌린지가 정해지지 않았습니다. 잠시 후 다시 시도해주세요.";
+        }
+
+        String imageUrl = null;
+        imageUrl = imageService.uploadFiles(createAndUpdateChallengeRequest.image());
+
+        Challenge challenge = challengeRepository.save(Challenge.builder()
+                //.title(todayChallenge.get().getTitle())
+                .title(todayChallenge)
+                .content(createAndUpdateChallengeRequest.content())
+                .image(imageUrl)
+                .user(user)
+                .active(true)
+                .challengeDate(todayDate)
+                .build());
+
+        return challenge.getTitle();
+    }
+
+    /**
+     * 챌린지 전체 조회(페이징)
+     */
+    public Page<GetChallengeListResponse> getChallengeList(String randomId, Pageable pageable) {
+        Page<Challenge> challengePage = challengeRepository.findByUser_UserIdOrderByCreatedAtDesc(NanoId.of(randomId), pageable);
+
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        return challengePage.map(challenge -> GetChallengeListResponse.builder()
+                .title(challenge.getTitle())
+                // .writer(challenge.getUser().getNickname())
+                // .content(challenge.getContent())
+                .thumbnail(challenge.getImage())
+                .challengeDate(challenge.getCreatedAt().format(dateTimeFormatter))
+                .build());
+    }
+
+    /**
+     * 챌린지 상세 조회
+     */
+    public GetChallengeResponse getChallenge(Long challengeId) {
+        Challenge challenge = challengeRepository.findById(challengeId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 챌린지입니다."));
+
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        return GetChallengeResponse.builder()
+                .title(challenge.getTitle())
+                //.writer(challenge.getUser().getName())
+                .content(challenge.getContent())
+                .thumbnail(challenge.getImage())
+                .challengeDate(challenge.getCreatedAt().format(dateTimeFormatter))
+                .build();
+    }
+
+}

--- a/src/main/java/com/spring/GreenJoy/domain/challenge/dto/CreateAndUpdateChallengeRequest.java
+++ b/src/main/java/com/spring/GreenJoy/domain/challenge/dto/CreateAndUpdateChallengeRequest.java
@@ -1,0 +1,11 @@
+package com.spring.GreenJoy.domain.challenge.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record CreateAndUpdateChallengeRequest(
+        String title,
+        String randomId,
+        String content,
+        MultipartFile image
+) {
+}

--- a/src/main/java/com/spring/GreenJoy/domain/challenge/dto/GetChallengeListResponse.java
+++ b/src/main/java/com/spring/GreenJoy/domain/challenge/dto/GetChallengeListResponse.java
@@ -1,0 +1,13 @@
+package com.spring.GreenJoy.domain.challenge.dto;
+
+import lombok.Builder;
+
+@Builder
+public record GetChallengeListResponse(
+        String title,
+        // String writer,
+        // String content,
+        String thumbnail,
+        String challengeDate
+) {
+}

--- a/src/main/java/com/spring/GreenJoy/domain/challenge/dto/GetChallengeResponse.java
+++ b/src/main/java/com/spring/GreenJoy/domain/challenge/dto/GetChallengeResponse.java
@@ -1,0 +1,13 @@
+package com.spring.GreenJoy.domain.challenge.dto;
+
+import lombok.Builder;
+
+@Builder
+public record GetChallengeResponse(
+        String title,
+        // String writer,
+        String content,
+        String thumbnail,
+        String challengeDate
+) {
+}

--- a/src/main/java/com/spring/GreenJoy/domain/challenge/entity/Challenge.java
+++ b/src/main/java/com/spring/GreenJoy/domain/challenge/entity/Challenge.java
@@ -1,0 +1,40 @@
+package com.spring.GreenJoy.domain.challenge.entity;
+
+import com.spring.GreenJoy.domain.user.entity.User;
+import com.spring.GreenJoy.global.common.BaseTime;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.time.LocalDate;
+
+@Getter
+@Table(name = "Challenge")
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+@Entity
+@ToString
+public class Challenge extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long challengeId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(length = 100, nullable = false)
+    private String title;
+
+    private String content;
+
+    private String image;
+
+    private LocalDate challengeDate;
+
+    @ColumnDefault("false")
+    private boolean active;
+
+}


### PR DESCRIPTION
### 📌 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : Challenge 기능 구현
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 📝 변경사항 및 이유

- Challenge 기능 구현

### ✨ 작업 내역

- Challenge 기능 구현

### ❗ PR 특이 사항

- `GreenJoyApplication` 클래스의 `@EnableScheduling`을 주석 처리하면 DB에 챌린지가 저장되는 것을 막을 수 있습니다.
- `ChallengeService` 클래스의 `createTodayChallenge()`에서 `@Scheduled`을 적용하였으며, 배포용 스케쥴러와 테스트용 스케쥴러를 분리했습니다.
